### PR TITLE
compile-time printf-warnings

### DIFF
--- a/include/logger.hh
+++ b/include/logger.hh
@@ -1,17 +1,17 @@
 // This file is part of monofonIC (MUSIC2)
 // A software package to generate ICs for cosmological simulations
 // Copyright (C) 2020 by Oliver Hahn & Michael Michaux (this file)
-// 
+//
 // monofonIC is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // monofonIC is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
@@ -127,7 +127,7 @@ public:
     return *this;
   }
 
-  inline void Print(const char *str, ...) {
+  inline void Print(const char *str, ...) __attribute__ ((format (printf, 2, 3))) {
     char out[1024];
     va_list argptr;
     va_start(argptr, str);


### PR DESCRIPTION
Transfering https://bitbucket.org/ohahn/monofonic/pull-requests/38 over to Github

This makes sure that arguments to `Print()` are handled the same way as arguments to `printf ` and cause compiler-warnings if the format-strings are incorrect.

I have not tested if this fails in older versions of GCC and Clang (or other C++ compilers)