### PR TITLE
fix typo in ternary operator

### DIFF
--- a/src/ic_generator.cc
+++ b/src/ic_generator.cc
@@ -534,7 +534,7 @@ int run( config_file& the_config )
             if( the_output_plugin->write_species_as( this_species ) == output_type::particles )
             {
                 // somewhat arbitrarily, start baryon particle IDs from 2**31 if we have 32bit and from 2**56 if we have 64 bits
-                size_t IDoffset = (this_species == cosmo_species::baryon)? ((the_output_plugin->has_64bit_ids())? 1 : 1): 0 ;
+                size_t IDoffset = (this_species == cosmo_species::baryon) ? the_output_plugin->has_64bit_ids() : 0;
 
                 // allocate particle structure and generate particle IDs
                 bool secondary_lattice = (this_species == cosmo_species::baryon &&


### PR DESCRIPTION
Moving from https://bitbucket.org/ohahn/monofonic/pull-requests/37 to Github