### PR TITLE
name output files after config and write output log

### DIFF
--- a/include/config_file.hh
+++ b/include/config_file.hh
@@ -162,6 +162,9 @@ public:
 
       items_[in_section + '/' + name] = value;
     }
+      size_t lastindex = filename.find_last_of('.');
+      std::string config_basename = filename.substr(0, lastindex);
+      items_["meta/config_basename"] = config_basename;
   }
 
   //! inserts a key/value pair in the hash map
@@ -286,6 +289,12 @@ public:
   template <class T>
   T get_value_safe(std::string const &key, T default_value) const {
     return get_value_safe("", key, default_value);
+  }
+
+  std::string get_path_relative_to_config(std::string const &filename) const {
+    std::string empty_string;
+    const std::string basename = get_value_safe("meta", "config_basename", empty_string);
+    return basename + "_" + filename;
   }
 
   //! dumps all key-value pairs to a std::ostream

--- a/src/ic_generator.cc
+++ b/src/ic_generator.cc
@@ -209,8 +209,8 @@ int run( config_file& the_config )
     const real_t astart = 1.0/(1.0+zstart);
     const real_t volfac(std::pow(boxlen / ngrid / 2.0 / M_PI, 1.5));
 
-    the_cosmo_calc->write_powerspectrum(astart, "input_powerspec.txt" );
-    the_cosmo_calc->write_transfer("input_transfer.txt" );
+    the_cosmo_calc->write_powerspectrum(astart, the_config.get_path_relative_to_config("input_powerspec.txt"));
+    the_cosmo_calc->write_transfer(the_config.get_path_relative_to_config("input_transfer.txt"));
 
     // the_cosmo_calc->compute_sigma_bc();
     // abort();
@@ -763,7 +763,7 @@ int run( config_file& the_config )
                 }, psi);
 
                 the_output_plugin->write_grid_data( rho, this_species, fluid_component::density );
-                rho.Write_PowerSpectrum("input_powerspec_sampled_evolved_semiclassical.txt");
+                rho.Write_PowerSpectrum(the_config.get_path_relative_to_config("input_powerspec_sampled_evolved_semiclassical.txt"));
                 rho.FourierTransformBackward();
                 
                 //======================================================================

--- a/src/main.cc
+++ b/src/main.cc
@@ -148,6 +148,12 @@ int main( int argc, char** argv )
 
     // open the configuration file 
     config_file the_config(argv[1]);
+    std::string log_filename = the_config.get_path_relative_to_config("log.txt");
+    music::logger::set_output(log_filename);
+    music::ilog << "                         argv[1] : " << argv[1] << std::endl;
+    music::ilog << "                 config_basename : " << the_config.get_path_relative_to_config("") << std::endl;
+    music::ilog << "                        log file : " << log_filename << std::endl;
+    music::ilog << "-------------------------------------------------------------------------------" << std::endl;
 
     //------------------------------------------------------------------------------
     // Set up FFTW

--- a/src/plugins/transfer_CLASS.cc
+++ b/src/plugins/transfer_CLASS.cc
@@ -203,7 +203,7 @@ public:
   {
     this->tf_isnormalised_ = true;
 
-    ofs_class_input_.open("input_class_parameters.ini", std::ios::trunc);
+    ofs_class_input_.open(cf.get_path_relative_to_config("input_class_parameters.ini"), std::ios::trunc);
 
     // all cosmological parameters need to be passed through the_cosmo_calc
     


### PR DESCRIPTION
This is something that annoyed me for a long time, so I finally fixed it:

When running monofonic on two config files:
```
monofonIC config-test-a.conf
monofonIC config-test-b.conf
```
both of them will write their data into e.g. `input_powerspec.txt` and therefore overwrite the values of the first run making it hard to remember which config file which output belongs to and compare them.

Even worse when running
```
monofonIC test-a/config.conf
monofonIC test-b/config.conf
```
in both cases the `input_powerspec.txt` ends up in the current directory instead of the one where the config is.

So I changed it that the config object also stores it's location and basename and therefore we can then name the output files e.g. `config-test-a_input_powerspec.txt`.

And in addition I added the output log at `config-test-a_log.txt` like in music.