### PR TITLE
support a MUSIC2 compatible RNG

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -107,7 +107,8 @@ seed           = 12345
 
 ##> The MUSIC1 multi-scale random number generator is provided for convenience
 ## warning: MUSIC1 generator is not MPI parallel (yet) (memory is needed for full field on each task)
-# generator      = MUSIC1  
+# generator      = MUSIC1
+# music2_rng     = false
 # seed[7]        = 12345
 # seed[8]        = 23456
 # seed[9]        = 34567

--- a/src/plugins/random_music.cc
+++ b/src/plugins/random_music.cc
@@ -216,6 +216,11 @@ void RNG_music::parse_random_parameters(void)
 void RNG_music::compute_random_numbers(void)
 {
   bool rndsign = pcf_->get_value_safe<bool>("random", "grafic_sign", false);
+  bool music2_rng = pcf_->get_value_safe<bool>("random", "music2_rng", false);
+  if (music2_rng)
+  {
+    music::ilog.Print("MUSIC1 RNG plugin: using MUSIC2 compatible seeds");
+  }
 
   //--- FILL ALL WHITE NOISE ARRAYS FOR WHICH WE NEED THE FULL FIELD ---//
 
@@ -235,9 +240,9 @@ void RNG_music::compute_random_numbers(void)
       //#warning add possibility to read noise from file also here!
 
       if (rngfnames_[i].size() > 0)
-        music::ilog.Print("Warning: Cannot use filenames for higher levels currently! Ignoring!");
+        music::wlog.Print("Warning: Cannot use filenames for higher levels currently! Ignoring!");
 
-      randc_[i] = new rng(*randc_[i - 1], ran_cube_size_, rngseeds_[i], true);
+      randc_[i] = new rng(*randc_[i - 1], ran_cube_size_, rngseeds_[i], music2_rng, true);
       delete randc_[i - 1];
       randc_[i - 1] = NULL;
     }

--- a/src/plugins/random_music_wnoise_generator.hh
+++ b/src/plugins/random_music_wnoise_generator.hh
@@ -162,7 +162,7 @@ public:
   music_wnoise_generator(unsigned res, unsigned cubesize, long baseseed, int *x0, int *lx);
 
   //! constructor for constrained fine field
-  music_wnoise_generator(music_wnoise_generator<T> &rc, unsigned cubesize, long baseseed,
+  music_wnoise_generator(music_wnoise_generator<T> &rc, unsigned cubesize, long baseseed, bool music2_rng,
                          bool kspace = false, bool isolated = false, int *x0_ = NULL, int *lx_ = NULL, bool zeromean = true);
 
   //! constructor


### PR DESCRIPTION
- backport MUSIC2 RNG changes (https://github.com/cosmo-sims/MUSIC2/commit/a616b2ebf63fd71c86c5228513cae43afb69859b) to monofonIC

- adding a new `music2_rng` option for this to the `[random]` section of the config (defaulting to the previous convention)