### PR TITLE
use Planck2018EE+BAO+SN defaults in example.conf

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -36,16 +36,17 @@ ParticleLoad    = sc       # particle load, can be 'sc' (1x), 'bcc' (2x) or 'fcc
 
 ParameterSet    = Planck2018EE+BAO+SN  # specify a pre-defined parameter set, or set to 'none' and set manually below
 
-## cosmological parameters, to set, choose ParameterSet = none,
+## Cosmological parameters
+## to set, choose ParameterSet = none above
 ## default values (those not specified) are set to the values
 ## from 'Planck2018EE+BAO+SN', we currently assume flatness
-# Omega_m         = 0.3158
-# Omega_b         = 0.0494
-# Omega_L         = 0.6842
-# H0              = 67.321
-# n_s             = 0.9661
-# sigma_8         = 0.8102
-# A_s             = 2.148752e-09  # can use A_s instead of sigma_8 when using CLASS 
+# Omega_m         = 0.3099
+# Omega_b         = 0.048891054
+# Omega_L         = 0.6901
+# H0              = 67.742
+# n_s             = 0.96822
+## sigma_8         = 0.808992
+# A_s             = 2.1064e-9  # can use A_s instead of sigma_8 when using CLASS 
 # Tcmb            = 2.7255
 # k_p             = 0.05
 # N_ur            = 2.046


### PR DESCRIPTION
taken from
https://github.com/cosmo-sims/monofonIC/blob/22e71a50b391e97e0e4c39b327b1c8261953e360/src/cosmology_parameters.cc#L89-L105

Also added `##` to `sigma_8` to indicate that it is different from the other parameters and doesn't have a `Planck2018EE+BAO+SN` default (so one should not uncomment all lines at the same time).